### PR TITLE
[WIP] Add Adaptive 2.0 support to Schemer

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,0 +1,3 @@
+{
+    "directory": "/bower_components"
+}


### PR DESCRIPTION
Status: **Opened for visibility**
Reviewers: **@donnielrt @fractaltheory @haroldtreen @mobify-derrick**
## Changes
- Added bowerrc file to set directory location for schemer. 
- Get view list for adaptive 2.0 projects
## To Do:
- [x] Finish adding support for Adaptive 2.0
- [ ] Add tests
- [ ] Engineer +2

How to Test
- Check out this repo
- Set up the executable by running npm link
- Switch to an Adaptive 2.0 project with integration tests written (ensures testing infrastructure is set up)
- Run the schemer command, and navigation to localhost:3000/schemer
- Ensure that views from the selected project show up in the list
- Create a schema for a view with a fixture present
- Ensure that the schema is valid by opening it up in an editor
